### PR TITLE
feat: add monitoring/alerting, storage buckets, cloud scheduler, pub/sub, and SQL backups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:20 AS base
+FROM node:22 AS base
 
 WORKDIR /home/node/app
 
 COPY package*.json ./
 
-RUN npm i
+RUN npm ci --omit=dev
 
 COPY . .
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,12 @@ The infrastructure includes the following components:
 1. **VPC Network**: A Virtual Private Cloud network to securely connect your resources.
 2. **Cloud Run**: A fully managed environment for deploying and scaling containerized applications.
 3. **Cloud SQL**: A fully managed relational database service for PostgreSQL.
-4. **IAM Roles**: Identity and Access Management roles for handling migrations, deployment, and secrets access.
-5. **CI/CD**: Prisma database migration and deployment configurations triggered on branch updates.
+4. **Redis (Memorystore)**: A managed in-memory cache attached to the VPC network.
+5. **Cloud Storage Buckets**: Private and public buckets for file storage, with CORS configured for browser uploads.
+6. **Cloud Scheduler**: Cron jobs that call the API on a schedule (signals, syncs, snapshots, etc.).
+7. **Monitoring & Alerting**: Cloud Monitoring alert policies (Cloud Run 5xx, app error logs, deploy/migration build failures) delivered to email and/or Slack. See [Monitoring & Alerting](#-monitoring--alerting).
+8. **IAM Roles**: Identity and Access Management roles for handling migrations, deployment, and secrets access.
+9. **CI/CD**: Prisma database migration and deployment configurations triggered on branch updates.
 
 ## 📝 Prerequisites
 
@@ -92,6 +96,89 @@ To create another environment (production, staging, etc.), complete the followin
 2. Update the environment variables in `terraform.tfvars` to match the environment.
 3. Proceed from **step 6** in the **Deployment Steps** section.
 
+
+## 📊 Monitoring & Alerting
+
+The `monitoring/` module provisions [Cloud Monitoring](https://cloud.google.com/monitoring/docs) notification channels and alert policies. Alerts fire to **email**, **Slack**, or both — whatever you configure. If neither an email nor a Slack channel is set, the build/migration/error-log alerts are simply not created.
+
+### What is monitored
+
+| Alert policy | Trigger | Type |
+| --- | --- | --- |
+| **Cloud Run 5xx errors** | The service returns any `5xx` response (request count > 0, 60s window). | Metric threshold |
+| **App error logs** | The app emits an `ERROR`-level log. Matches Cloud Logging `severity>=ERROR` **or** Pino's `jsonPayload.level>=50` (50 = error, 60 = fatal), because Cloud Run maps stdout to `INFO`. | Log match |
+| **Deploy failed** | The service's Cloud Build **deploy** trigger produces an `ERROR` log. | Log match |
+| **Migration failed** | The service's Cloud Build **migration** trigger produces an `ERROR` log. | Log match |
+
+Every alert's notification includes a deep link to the exact Logs Explorer query or the specific failed build, so you can jump straight to the relevant logs from Slack/email.
+
+The 5xx alert is always created. The other three are gated by `enable_deploy_alert`, `enable_migration_alert`, and `enable_error_log_alert` (all enabled in `tf/dev/main.tf` and `tf/prod/main.tf`).
+
+### Configuration
+
+The module is wired in each root module (`tf/dev/main.tf`, `tf/prod/main.tf`) via `module "monitoring"`. The values you actually set per environment live in `terraform.tfvars`:
+
+```terraform
+# tf/<env>/terraform.tfvars
+
+# Email recipients. Empty list = email channel disabled (Slack only).
+alert_emails = ["devops@example.com"]
+
+# Slack channel + the Secret Manager secret holding the Slack bot token.
+# Empty slack_channel_name = Slack disabled (email only).
+slack_channel_name         = "#tolmete-alerts-dev"
+slack_auth_token_secret_id = "projects/97812123028/secrets/SLACK_ALERTING_TOKEN"
+```
+
+Key module variables (see `tf/modules/monitoring/variables.tf`):
+
+| Variable | Purpose |
+| --- | --- |
+| `alert_emails` | List of emails to notify. Empty disables the email channel. |
+| `slack_channel_name` | Slack channel to post to (e.g. `#alerts`). Empty disables Slack. |
+| `slack_auth_token_secret_id` | Full Secret Manager secret path holding the Slack bot token. **Required** when `slack_channel_name` is set. |
+| `enable_deploy_alert` / `deploy_trigger_id` | Toggle + Cloud Build deploy trigger ID for the deploy-failure alert. |
+| `enable_migration_alert` / `migration_trigger_id` | Toggle + Cloud Build migration trigger ID for the migration-failure alert. |
+| `enable_error_log_alert` | Toggle the app `ERROR`-log alert. |
+
+### Tutorial: Creating Slack alerts
+
+Follow these steps to wire alerts into a Slack channel.
+
+1. **Create (or pick) a Slack channel** for alerts, e.g. `#tolmete-alerts-dev`.
+
+2. **Create a Slack app with a bot token.**
+    1. Go to <https://api.slack.com/apps> → **Create New App** → **From scratch**. Name it (e.g. `GCP Alerts`) and select your workspace.
+    2. Open **OAuth & Permissions** → **Scopes** → **Bot Token Scopes** and add `chat:write`.
+    3. Click **Install to Workspace** and authorize. Copy the **Bot User OAuth Token** (starts with `xoxb-`).
+    4. In Slack, invite the bot to the channel: `/invite @GCP Alerts` in `#tolmete-alerts-dev`.
+
+    > Alternatively, Cloud Monitoring can connect Slack via its own OAuth flow when you create a Slack channel in the console — but storing your own bot token in Secret Manager (below) keeps the setup fully in Terraform and reproducible.
+
+3. **Store the token in Secret Manager.** Create a secret (e.g. `SLACK_ALERTING_TOKEN`) and add the bot token as a secret version:
+    ```bash
+    gcloud secrets create SLACK_ALERTING_TOKEN --replication-policy=automatic --project=<project-id>
+    printf '%s' 'xoxb-your-bot-token' | gcloud secrets versions add SLACK_ALERTING_TOKEN --data-file=- --project=<project-id>
+    ```
+    Copy the full secret path from the secret's detail page, e.g. `projects/97812123028/secrets/SLACK_ALERTING_TOKEN`.
+
+4. **Point the environment at the channel and secret** in `tf/<env>/terraform.tfvars`:
+    ```terraform
+    slack_channel_name         = "#tolmete-alerts-dev"
+    slack_auth_token_secret_id = "projects/97812123028/secrets/SLACK_ALERTING_TOKEN"
+    ```
+
+5. **Grant the channel access (one-time).** The first time you save a Slack secret, ensure the secret exists before `terraform apply` — the module reads the token via a `google_secret_manager_secret_version` data source at plan time. Your Terraform principal needs `secretmanager.versions.access` on that secret.
+
+6. **Apply.** From `tf/<env>`:
+    ```bash
+    terraform apply
+    ```
+    This creates the `Slack Alert - #tolmete-alerts-dev` notification channel and attaches it to all alert policies.
+
+7. **Verify.** In the GCP Console go to **Monitoring → Alerting → Edit notification channels**, find the Slack channel, and click **Send test notification**. You should see a message appear in the Slack channel.
+
+To **disable** Slack later, clear `slack_channel_name = ""` and re-apply. The channels use `force_delete = true`, so they can be removed even while still referenced by an alert policy.
 
 ## 📂 Template Structure
 

--- a/tf/dev/main.tf
+++ b/tf/dev/main.tf
@@ -21,7 +21,7 @@ provider "google" {
 }
 
 resource "google_storage_bucket" "tfstate" {
-  name     = "${var.environment}-${var.project}-tfstate"
+  name     = "${var.environment}-${var.project}-${var.service_name}-tfstate"
   location = var.region
 
   force_destroy               = false
@@ -56,6 +56,21 @@ resource "local_file" "backend" {
   EOT
 }
 
+module "public_bucket" {
+  source      = "../modules/bucket"
+
+  project                = var.project
+  region                 = var.region
+  bucket_name            = var.public_bucket_name
+  cors_allowed_origins   = var.public_bucket_cors_allowed_origins
+  cloud_run_sa_email     = module.cloud_run.cloud_run_sa_email
+  bucket_public_access   = true
+
+  depends_on = [
+    module.cloud_run
+  ]
+}
+
 module "project_api" {
   source = "../modules/project-api"
 }
@@ -76,12 +91,62 @@ module "secret" {
   environment = var.environment
 }
 
+module "monitoring" {
+  source = "../modules/monitoring"
+
+  project                    = var.project
+  service_name               = var.service_name
+  alert_emails               = var.alert_emails
+  slack_channel_name         = var.slack_channel_name
+  slack_auth_token_secret_id = var.slack_auth_token_secret_id
+
+  enable_deploy_alert    = true
+  deploy_trigger_id      = module.cloud_run.deploy_trigger_id
+  enable_migration_alert = true
+  migration_trigger_id   = module.cloud_sql.migration_trigger_id
+  enable_error_log_alert = true
+
+  # Only depend on API enablement. Trigger-ID references already create implicit deps on the
+  # Cloud Build triggers, so the alerts can deploy even when the Cloud Run service is unhealthy.
+  depends_on = [module.project_api]
+}
+# module "cron_1day" {
+#   source      = "../modules/cloud-scheduler"
+#   name        = "${var.service_name}-cron-1day"
+#   description = "Cron job every day"
+#   schedule    = "0 0 * * *"
+#   time_zone   = "America/New_York"
+#   http_method = "GET"
+#   uri         = "${var.cloud_run_application_url}/api/ping"
+#   project     = var.project
+
+#   headers = {
+#     "Content-Type" = "application/json"
+#     "User-Agent"   = "Google-Cloud-Scheduler"
+#   }
+
+#   body = jsonencode({})
+
+#   depends_on = [
+#     module.cloud_run,
+#   ]
+# }
+
+# module "pubsub_test" {
+#   source           = "../modules/pub-sub"
+#   project          = var.project
+#   service_name     = var.service_name
+#   topic_name       = "test"
+#   subscription_name = "test-sub"
+# }
+
 module "cloud_run" {
   source = "../modules/cloud-run"
 
   set_dummy_image = var.cloud_run_set_dummy_image
 
   project = var.project
+  project_number = var.project_number
   region  = var.region
 
   environment = var.environment
@@ -125,8 +190,10 @@ module "cloud_sql" {
 
   project                = var.project
   region                 = var.region
+  allowed_ips            = var.cloud_sql_allowed_ips
   db_instance_name       = var.db_instance_name
   db_deletion_protection = var.cloud_sql_db_deletion_protection
+  database_flags         = var.cloud_sql_database_flags
 
   gh_owner       = var.gh_owner
   gh_repo_name   = var.gh_repo_name

--- a/tf/dev/terraform.tfvars
+++ b/tf/dev/terraform.tfvars
@@ -1,19 +1,36 @@
 project = "project-id"        // GCP project ID, e.g. tokyo-rain-123
-region  = "europe-central2"   // Region where to deploy resources, e.g. europe-central2
-zone    = "europe-central2-a" // Region zone where to deploy resources, e.g. europe-central2-a
+project_number = 00000000
+region  = "us-central1"   // Region where to deploy resources, e.g. europe-central2
+zone    = "us-central1-a" // Region zone where to deploy resources, e.g. europe-central2-a
 
 environment      = "dev"                 // dev, prod, staging, etc. This environment will be added as a prefix for the created resources. 
-service_name     = "dev-my-project-name" // Service name will be used as a name for Cloud run, VPC, Service Accounts, IAM roles.
-db_instance_name = "dev-database-name"   // DB instance name will be used as a name for Cloud SQL instance.
+service_name     = "dev-api" // Service name will be used as a name for Cloud run, VPC, Service Accounts, IAM roles.
+db_instance_name = "dev-db"   // DB instance name will be used as a name for Cloud SQL instance.
+
+// Either provide list of emails or slack channel with app token
+// Alerting module configuration (deploy build failures -> email + Slack)
+alert_emails = []
+slack_channel_name         = "#channel-name"
+slack_auth_token_secret_id = "projects/97812123028/secrets/SLACK_TOKEN"
+
+public_bucket_name                 = "dev-public"
+public_bucket_cors_allowed_origins = ["https://localhost:3000", "http://localhost:3000", "https://127.0.0.1:3000", "http://127.0.0.1:3000"]
 
 // Github repository for deployment configuration
 gh_owner       = "lumitech-co"             // Github owner of the repository.
-gh_repo_name   = "project-repository-name" // Repository name.
-gh_branch_name = "main"                    // Branch name to trigger new revisions from.
+gh_repo_name   = "dev-api" // Repository name.
+gh_branch_name = "dev"                    // Branch name to trigger new revisions from.
 
 // Cloud SQL module configuration
 cloud_sql_db_deletion_protection = true          // Enable deletion protection for the Cloud SQL instance. Production version must have this enabled.
 cloud_sql_tier                   = "db-f1-micro" // Cloud SQL tier for the instance. Default is the cheapest tier. More options: https://cloud.google.com/sdk/gcloud/reference/sql/tiers/list
+cloud_sql_allowed_ips            = []
+cloud_sql_database_flags         = [
+  {
+    name  = "max_connections"
+    value = "100"
+  }
+]
 
 // Cloud Run module configuration
 cloud_run_application_url       = "http://0.0.0.0:3001" // Update to the hardcoded API URL after resources creation.
@@ -23,5 +40,11 @@ cloud_run_instance_limit_cpus   = 1                     // The number of CPUs to
 
 cloud_run_set_dummy_image = true // Set to TRUE when initially deploying the infrastructure in order to avoid an error. Update to false after the first deployment.
 
+api_environment_variables = {
+    cors_origin="http://localhost:3000,http://127.0.0.1:3000"
+}
+
 // Cloud Run Secret Manager secrets
-// example_secret_for_cloud_run = "projects/123456789102/secrets/dev-some-secret" // Provide custom secrets for the Cloud Run service.
+api_secret_keys = {
+    # google_places_api_key = "projects/97812123028/secrets/GOOGLE_PLACES_API_KEY"
+}

--- a/tf/dev/variables.tf
+++ b/tf/dev/variables.tf
@@ -7,6 +7,11 @@ variable "project" {
   description = "The GCP project ID to deploy resources"
 }
 
+variable "project_number" {
+  type        = number
+  description = "The GCP project number to deploy resources"
+}
+
 variable "region" {
   type        = string
   description = "Region where to deploy resources"
@@ -25,6 +30,33 @@ variable "environment" {
 variable "service_name" {
   description = "Deployed resources naming e.g. my-project-name"
   type        = string
+}
+
+variable "alert_emails" {
+  description = "Email addresses to notify on Cloud Run 5xx alerts"
+  type        = list(string)
+}
+
+variable "slack_channel_name" {
+  description = "Slack channel to post 5xx alerts to (e.g. #alerts). Empty disables Slack."
+  type        = string
+  default     = ""
+}
+
+variable "slack_auth_token_secret_id" {
+  description = "Secret Manager secret id holding the Slack auth token for the alert channel"
+  type        = string
+  default     = ""
+}
+
+variable "public_bucket_name" {
+  description = "Deployed resources naming e.g. my-project-name"
+  type        = string
+}
+
+variable "public_bucket_cors_allowed_origins" {
+  description = "List of allowed origins for browser uploads (CORS)"
+  type        = list(string)
 }
 
 variable "gh_branch_name" {
@@ -86,3 +118,31 @@ variable "cloud_sql_db_deletion_protection" {
   type        = bool
 }
 
+variable "cloud_sql_allowed_ips" {
+  description = "List of IP addresses or CIDR blocks allowed to access Cloud SQL"
+  type        = list(string)
+  default     = []
+}
+
+variable "cloud_sql_database_flags" {
+  description = "Database flags to set on the Cloud SQL instance"
+  type        = list(object({
+    name  = string
+    value = string
+  }))
+  default = []
+}
+
+
+variable "api_environment_variables" {
+  description = "Environment variables for the api container"
+  type = object({
+    cors_origin = string
+  })
+}
+
+variable "api_secret_keys" {
+  description = "Secret keys for the API container"
+  type = object({
+  })
+}

--- a/tf/modules/bucket/iam.tf
+++ b/tf/modules/bucket/iam.tf
@@ -1,0 +1,21 @@
+# Cloud Run — full object access (always)
+resource "google_storage_bucket_iam_member" "cloud_run_rw" {
+  bucket = google_storage_bucket.bucket.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${var.cloud_run_sa_email}"
+}
+
+resource "google_service_account_iam_member" "cloud_run_signer" {
+  service_account_id = "projects/${var.project}/serviceAccounts/${var.cloud_run_sa_email}"
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${var.cloud_run_sa_email}"
+}
+
+# Public read — only if enabled
+resource "google_storage_bucket_iam_member" "public_read" {
+  count  = var.bucket_public_access ? 1 : 0
+
+  bucket = google_storage_bucket.bucket.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}

--- a/tf/modules/bucket/main.tf
+++ b/tf/modules/bucket/main.tf
@@ -1,0 +1,23 @@
+resource "google_storage_bucket" "bucket" {
+  name     = var.bucket_name
+  location = var.region
+
+  force_destroy               = true
+  uniform_bucket_level_access = true
+  public_access_prevention    = "inherited"
+
+  versioning {
+    enabled = true
+  }
+
+  dynamic "cors" {
+    for_each = length(var.cors_allowed_origins) > 0 ? [1] : []
+
+    content {
+      origin          = var.cors_allowed_origins
+      method          = ["GET", "PUT", "POST", "HEAD"]
+      response_header = ["Content-Type", "Authorization"]
+      max_age_seconds = 3600
+    }
+  }
+}

--- a/tf/modules/bucket/output.tf
+++ b/tf/modules/bucket/output.tf
@@ -1,0 +1,4 @@
+output "bucket_name" {
+  description = "The private bucket name"
+  value       = google_storage_bucket.bucket.name
+}

--- a/tf/modules/bucket/variables.tf
+++ b/tf/modules/bucket/variables.tf
@@ -1,0 +1,30 @@
+variable "project" {
+  description = "GCP Project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "bucket_name" {
+  description = "Name of the bucket"
+  type        = string
+}
+
+variable "bucket_public_access" {
+  description = "Whether the GCS bucket should allow public access (true = public, false = private)"
+  type        = bool
+}
+
+variable "cloud_run_sa_email" {
+  description = "Email of the Cloud Run service account that will access resources (e.g., bucket, Pub/Sub)"
+  type        = string
+}
+
+variable "cors_allowed_origins" {
+  description = "List of allowed origins for browser uploads (CORS)"
+  type        = list(string)
+}

--- a/tf/modules/cloud-run/iam.tf
+++ b/tf/modules/cloud-run/iam.tf
@@ -27,7 +27,7 @@ resource "google_project_iam_member" "cloud_run_invoker" {
   member  = "serviceAccount:${google_service_account.cloud_run_sa.email}"
 }
 
-resource "google_project_iam_member" "cloub_run_logging" {
+resource "google_project_iam_member" "cloud_run_logging" {
   project = var.project
   role    = "roles/logging.logWriter"
   member  = "serviceAccount:${google_service_account.cloud_run_sa.email}"
@@ -54,25 +54,25 @@ resource "google_project_iam_member" "act_as" {
   member  = "serviceAccount:${google_service_account.cloud_build.email}"
 }
 
-resource "google_project_iam_member" "cloub_build_artifact" {
+resource "google_project_iam_member" "cloud_build_artifact" {
   project = var.project
   role    = "roles/artifactregistry.writer"
   member  = "serviceAccount:${google_service_account.cloud_build.email}"
 }
 
-resource "google_project_iam_member" "cloub_build_run" {
+resource "google_project_iam_member" "cloud_build_run" {
   project = var.project
   role    = "roles/run.admin"
   member  = "serviceAccount:${google_service_account.cloud_build.email}"
 }
 
-resource "google_project_iam_member" "cloub_build_source" {
+resource "google_project_iam_member" "cloud_build_source" {
   project = var.project
   role    = "roles/source.reader"
   member  = "serviceAccount:${google_service_account.cloud_build.email}"
 }
 
-resource "google_project_iam_member" "cloub_build_logging" {
+resource "google_project_iam_member" "cloud_build_logging" {
   project = var.project
   role    = "roles/logging.logWriter"
   member  = "serviceAccount:${google_service_account.cloud_build.email}"

--- a/tf/modules/cloud-run/outputs.tf
+++ b/tf/modules/cloud-run/outputs.tf
@@ -2,3 +2,10 @@ output "api_url" {
   value = google_cloud_run_v2_service.node-api.uri
 }
 
+output "cloud_run_sa_email" {
+  value = google_service_account.cloud_run_sa.email
+}
+
+output "deploy_trigger_id" {
+  value = google_cloudbuild_trigger.run_deploy.trigger_id
+}

--- a/tf/modules/cloud-run/variables.tf
+++ b/tf/modules/cloud-run/variables.tf
@@ -3,6 +3,11 @@ variable "project" {
   description = "The GCP project ID to deploy resources"
 }
 
+variable "project_number" {
+  type        = number
+  description = "The GCP project number to deploy resources"
+}
+
 variable "region" {
   type        = string
   description = "Region where to deploy resources"

--- a/tf/modules/cloud-scheduler/main.tf
+++ b/tf/modules/cloud-scheduler/main.tf
@@ -1,0 +1,30 @@
+resource "google_project_service" "cloud_scheduler" {
+  project            = var.project
+  service            = "cloudscheduler.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_cloud_scheduler_job" "cron" {
+  name        = var.name
+  description = var.description
+  schedule    = var.schedule
+  time_zone   = var.time_zone
+
+  http_target {
+    http_method = var.http_method
+    uri         = var.uri
+
+    headers = merge(
+      {
+        "User-Agent"   = "Google-Cloud-Scheduler"
+      },
+      var.headers
+    )
+
+    body    = var.body != null ? base64encode(var.body) : null
+  }
+
+  depends_on = [
+    google_project_service.cloud_scheduler
+  ]
+}

--- a/tf/modules/cloud-scheduler/variables.tf
+++ b/tf/modules/cloud-scheduler/variables.tf
@@ -1,0 +1,55 @@
+variable "name" {
+  description = "Name of the cron job"
+  type        = string
+}
+
+variable "project" {
+  type        = string
+  description = "The GCP project ID to deploy resources"
+}
+
+variable "description" {
+  description = "Description of the cron job"
+  type        = string
+  default     = ""
+}
+
+variable "schedule" {
+  description = "Cron expression schedule"
+  type        = string
+}
+
+variable "time_zone" {
+  description = "Time zone for the job"
+  type        = string
+  default     = "Etc/UTC"
+}
+
+variable "http_method" {
+  description = "HTTP method"
+  type        = string
+  default     = "GET"
+}
+
+variable "uri" {
+  description = "Target URL"
+  type        = string
+}
+
+variable "headers" {
+  description = "Optional HTTP headers"
+  type        = map(string)
+  default     = {}
+}
+
+variable "body" {
+  description = "Optional request body"
+  type        = string
+  default     = null
+}
+
+variable "target_type" {
+  description = "Target type: http or pubsub"
+  type        = string
+  default     = "http"
+}

--- a/tf/modules/cloud-sql/main.tf
+++ b/tf/modules/cloud-sql/main.tf
@@ -12,13 +12,34 @@ resource "google_sql_database_instance" "postgres" {
     edition                     = "ENTERPRISE"
     deletion_protection_enabled = var.db_deletion_protection
 
+    backup_configuration {
+      enabled                        = true
+      start_time                     = "00:00" # UTC
+      location                       = var.region
+      point_in_time_recovery_enabled = true
+      transaction_log_retention_days = 7
+    }
+
     ip_configuration {
       ipv4_enabled    = true
       private_network = var.network_self_link
 
-      authorized_networks {
-        name  = "all"
-        value = "0.0.0.0/0"
+      dynamic "authorized_networks" {
+        for_each = var.allowed_ips
+
+        content {
+          name  = "allowed-${replace(authorized_networks.value, "/", "-")}"
+          value = authorized_networks.value
+        }
+      }
+    }
+
+    dynamic "database_flags" {
+      for_each = var.database_flags
+
+      content {
+        name  = database_flags.value.name
+        value = database_flags.value.value
       }
     }
   }

--- a/tf/modules/cloud-sql/outputs.tf
+++ b/tf/modules/cloud-sql/outputs.tf
@@ -5,3 +5,7 @@ output "cloud_sql_instance_name" {
 output "database_url_secret_id" {
   value = google_secret_manager_secret.database_url.id
 }
+
+output "migration_trigger_id" {
+  value = google_cloudbuild_trigger.run_migration.trigger_id
+}

--- a/tf/modules/cloud-sql/variables.tf
+++ b/tf/modules/cloud-sql/variables.tf
@@ -50,3 +50,17 @@ variable "gh_repo_name" {
   type        = string
 }
 
+variable "allowed_ips" {
+  description = "List of IP addresses or CIDR blocks allowed to access Cloud SQL"
+  type        = list(string)
+}
+
+variable "database_flags" {
+  description = "Database flags to set on the Cloud SQL instance"
+  type        = list(object({
+    name  = string
+    value = string
+  }))
+  default = []
+}
+

--- a/tf/modules/monitoring/cloud_build.tf
+++ b/tf/modules/monitoring/cloud_build.tf
@@ -1,0 +1,166 @@
+locals {
+  build_history_url = "https://console.cloud.google.com/cloud-build/builds?project=${var.project}"
+
+  # Link to the EXACT failed build's logs. $${log.extracted_label.build_id} is substituted by
+  # Cloud Monitoring at notification time (escaped as $$ so Terraform emits the literal ${...});
+  # build_id is pulled from the triggering log entry via the label_extractors blocks below.
+  build_log_url = "https://console.cloud.google.com/cloud-build/builds;region=global/$${log.extracted_label.build_id}?project=${var.project}"
+
+  # Drive alerts off what's actually provided: notify whatever channels are set
+  # (email and/or Slack); if NEITHER is configured, create no build-failure alert.
+  has_notification_channel = length(var.alert_emails) > 0 || var.slack_channel_name != ""
+
+  # App ERROR-log filter. Pino (the backend logger) writes JSON to stdout with a numeric
+  # `jsonPayload.level` (50 = error, 60 = fatal); Cloud Run maps stdout to INFO, NOT ERROR,
+  # so matching severity>=ERROR alone misses app errors. We also match jsonPayload.level>=50.
+  error_logs_query = <<-EOT
+    resource.type="cloud_run_revision"
+    resource.labels.service_name="${var.service_name}"
+    (severity>=ERROR OR jsonPayload.level>=50)
+  EOT
+
+  # urlencode() encodes spaces as "+", but the Logs Explorer ;query= segment does NOT decode
+  # "+" back to a space, so "ERROR OR jsonPayload" would arrive as "ERROR+OR+jsonPayload" and
+  # be rejected as an invalid filter. Replace "+" with %20 so the spaces around OR survive.
+  error_logs_explorer_url = "https://console.cloud.google.com/logs/query;query=${replace(urlencode(trimspace(local.error_logs_query)), "+", "%20")}?project=${var.project}"
+}
+
+resource "google_monitoring_alert_policy" "deploy_failed" {
+  count = var.enable_deploy_alert && local.has_notification_channel ? 1 : 0
+
+  project      = var.project
+  display_name = "Deploy failed: ${var.service_name}"
+  combiner     = "OR"
+
+  documentation {
+    mime_type = "text/markdown"
+    subject   = "Cloud Build deploy failed for ${var.service_name}"
+    content   = "A Cloud Run *deploy* build for *${var.service_name}* failed.\n\n[View build logs](${local.build_log_url})"
+
+    links {
+      display_name = "Cloud Build history"
+      url          = local.build_history_url
+    }
+  }
+
+  conditions {
+    display_name = "Deploy build failed"
+
+    condition_matched_log {
+      # build_trigger_id scopes the match to THIS service+env's deploy trigger only.
+      filter = <<-EOT
+        resource.type="build"
+        resource.labels.build_trigger_id="${var.deploy_trigger_id}"
+        severity=ERROR
+      EOT
+
+      # Expose the failed build's id so the notification can link to the exact build.
+      label_extractors = {
+        "build_id" = "EXTRACT(resource.labels.build_id)"
+      }
+    }
+  }
+
+  notification_channels = concat(
+    [for c in google_monitoring_notification_channel.email : c.id],
+    google_monitoring_notification_channel.slack[*].id,
+  )
+
+  # Log-match policies require notification_rate_limit (not auto_close/notification_prompts).
+  # Collapses a multi-ERROR-line failed build into a single notification per 5 min.
+  alert_strategy {
+    notification_rate_limit {
+      period = "300s"
+    }
+  }
+}
+
+resource "google_monitoring_alert_policy" "app_error_log" {
+  count = var.enable_error_log_alert && local.has_notification_channel ? 1 : 0
+
+  project      = var.project
+  display_name = "App error logs: ${var.service_name}"
+  combiner     = "OR"
+
+  documentation {
+    mime_type = "text/markdown"
+    subject   = "App error log on ${var.service_name}"
+    content   = "Cloud Run service *${var.service_name}* emitted an ERROR-level log.\n\n[View error logs in Logs Explorer](${local.error_logs_explorer_url})"
+
+    links {
+      display_name = "Error logs"
+      url          = local.error_logs_explorer_url
+    }
+  }
+
+  conditions {
+    display_name = "App emitted an ERROR-level log"
+
+    condition_matched_log {
+      filter = <<-EOT
+        resource.type="cloud_run_revision"
+        resource.labels.service_name="${var.service_name}"
+        (severity>=ERROR OR jsonPayload.level>=50)
+      EOT
+    }
+  }
+
+  notification_channels = concat(
+    [for c in google_monitoring_notification_channel.email : c.id],
+    google_monitoring_notification_channel.slack[*].id,
+  )
+
+  # Log-match policies require notification_rate_limit. Collapses a burst of error logs
+  # into a single notification per 5 min so a failing endpoint doesn't spam the channel.
+  alert_strategy {
+    notification_rate_limit {
+      period = "300s"
+    }
+  }
+}
+
+resource "google_monitoring_alert_policy" "migration_failed" {
+  count = var.enable_migration_alert && local.has_notification_channel ? 1 : 0
+
+  project      = var.project
+  display_name = "Migration failed: ${var.service_name}"
+  combiner     = "OR"
+
+  documentation {
+    mime_type = "text/markdown"
+    subject   = "Cloud Build migration failed for ${var.service_name}"
+    content   = "A database *migration* build for *${var.service_name}* failed.\n\n[View build logs](${local.build_log_url})"
+
+    links {
+      display_name = "Cloud Build history"
+      url          = local.build_history_url
+    }
+  }
+
+  conditions {
+    display_name = "Migration build failed"
+
+    condition_matched_log {
+      filter = <<-EOT
+        resource.type="build"
+        resource.labels.build_trigger_id="${var.migration_trigger_id}"
+        severity=ERROR
+      EOT
+
+      label_extractors = {
+        "build_id" = "EXTRACT(resource.labels.build_id)"
+      }
+    }
+  }
+
+  notification_channels = concat(
+    [for c in google_monitoring_notification_channel.email : c.id],
+    google_monitoring_notification_channel.slack[*].id,
+  )
+
+  alert_strategy {
+    notification_rate_limit {
+      period = "300s"
+    }
+  }
+}

--- a/tf/modules/monitoring/main.tf
+++ b/tf/modules/monitoring/main.tf
@@ -1,0 +1,108 @@
+resource "google_monitoring_notification_channel" "email" {
+  for_each = toset(var.alert_emails)
+
+  project      = var.project
+  display_name = "Email Alert - ${each.value}"
+  type         = "email"
+
+  # Allow deletion even while an alert policy still references the channel, so removing
+  # an email from var.alert_emails doesn't fail with a "still being referenced" error.
+  force_delete = true
+
+  labels = {
+    email_address = each.value
+  }
+}
+
+# Do NOT set `project` here: slack_auth_token_secret_id is a full path
+# (projects/<number>/secrets/...). Setting project to the project ID conflicts with the
+# project number in the path. Omitting it lets the provider derive project from the path.
+data "google_secret_manager_secret_version" "slack_auth_token" {
+  count  = var.slack_channel_name != "" ? 1 : 0
+  secret = var.slack_auth_token_secret_id
+}
+
+resource "google_monitoring_notification_channel" "slack" {
+  count = var.slack_channel_name != "" ? 1 : 0
+
+  project      = var.project
+  display_name = "Slack Alert - ${var.slack_channel_name}"
+  type         = "slack"
+
+  # Allow deletion even while an alert policy still references the channel, so disabling
+  # Slack (clearing var.slack_channel_name) doesn't fail with a "still being referenced" error.
+  force_delete = true
+
+  labels = {
+    channel_name = var.slack_channel_name
+  }
+
+  sensitive_labels {
+    auth_token = data.google_secret_manager_secret_version.slack_auth_token[0].secret_data
+  }
+}
+
+locals {
+  logs_query = <<-EOT
+    resource.type="cloud_run_revision"
+    resource.labels.service_name="${var.service_name}"
+    severity>=ERROR
+  EOT
+
+  logs_explorer_url = "https://console.cloud.google.com/logs/query;query=${urlencode(trimspace(local.logs_query))}?project=${var.project}"
+}
+
+resource "google_monitoring_alert_policy" "cloud_run_5xx" {
+  project      = var.project
+  display_name = "${var.service_name} - Cloud Run 5xx errors"
+  combiner     = "OR"
+
+  documentation {
+    mime_type = "text/markdown"
+    subject   = "Cloud Run 5xx errors on ${var.service_name}"
+    content   = "Cloud Run service *${var.service_name}* is returning 5xx errors.\n\n[View error logs in Logs Explorer](${local.logs_explorer_url})"
+
+    links {
+      display_name = "Error logs"
+      url          = local.logs_explorer_url
+    }
+  }
+
+  conditions {
+    display_name = "5xx response count > 0"
+
+    condition_threshold {
+      filter = <<-EOT
+        resource.type = "cloud_run_revision"
+        AND resource.labels.service_name = "${var.service_name}"
+        AND metric.type = "run.googleapis.com/request_count"
+        AND metric.labels.response_code_class = "5xx"
+      EOT
+
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+      duration        = "0s"
+
+      aggregations {
+        alignment_period   = "60s"
+        per_series_aligner = "ALIGN_SUM"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  notification_channels = concat(
+    [for c in google_monitoring_notification_channel.email : c.id],
+    google_monitoring_notification_channel.slack[*].id,
+  )
+
+  alert_strategy {
+    auto_close = "1800s"
+
+    # Notify only when an incident opens, not when it auto-resolves.
+    notification_prompts = ["OPENED"]
+  }
+}

--- a/tf/modules/monitoring/outputs.tf
+++ b/tf/modules/monitoring/outputs.tf
@@ -1,0 +1,12 @@
+output "notification_channel_ids" {
+  description = "IDs of all notification channels (email + Slack)"
+  value = concat(
+    [for c in google_monitoring_notification_channel.email : c.id],
+    google_monitoring_notification_channel.slack[*].id,
+  )
+}
+
+output "alert_policy_id" {
+  description = "ID of the Cloud Run 5xx alert policy"
+  value       = google_monitoring_alert_policy.cloud_run_5xx.id
+}

--- a/tf/modules/monitoring/variables.tf
+++ b/tf/modules/monitoring/variables.tf
@@ -1,0 +1,62 @@
+variable "project" {
+  type        = string
+  description = "The GCP project ID to deploy resources"
+}
+
+variable "service_name" {
+  description = "Cloud Run service name to monitor for 5xx errors"
+  type        = string
+}
+
+variable "alert_emails" {
+  description = "Email addresses to notify on alerts. Empty disables email alerts."
+  type        = list(string)
+  default     = []
+}
+
+variable "slack_channel_name" {
+  description = "Slack channel to post 5xx alerts to (e.g. #alerts). Empty disables Slack."
+  type        = string
+  default     = ""
+}
+
+variable "slack_auth_token_secret_id" {
+  description = "Secret Manager secret id holding the Slack auth token for the alert channel"
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.slack_channel_name == "" || var.slack_auth_token_secret_id != ""
+    error_message = "slack_auth_token_secret_id is required when slack_channel_name is set."
+  }
+}
+
+variable "enable_deploy_alert" {
+  description = "Create a log-based alert when this service's Cloud Build deploy fails."
+  type        = bool
+  default     = false
+}
+
+variable "deploy_trigger_id" {
+  description = "Cloud Build deploy trigger ID (used in the failure log filter)."
+  type        = string
+  default     = ""
+}
+
+variable "enable_migration_alert" {
+  description = "Create a log-based alert when this service's Cloud Build migration fails."
+  type        = bool
+  default     = false
+}
+
+variable "migration_trigger_id" {
+  description = "Cloud Build migration trigger ID (used in the failure log filter)."
+  type        = string
+  default     = ""
+}
+
+variable "enable_error_log_alert" {
+  description = "Create a log-based alert when the app emits an ERROR-level (Pino level>=50) log."
+  type        = bool
+  default     = false
+}

--- a/tf/modules/project-api/main.tf
+++ b/tf/modules/project-api/main.tf
@@ -35,3 +35,8 @@ resource "google_project_service" "sqladmin" {
   service            = "sqladmin.googleapis.com"
   disable_on_destroy = false
 }
+
+resource "google_project_service" "monitoring" {
+  service            = "monitoring.googleapis.com"
+  disable_on_destroy = false
+}

--- a/tf/modules/pub-sub/main.tf
+++ b/tf/modules/pub-sub/main.tf
@@ -1,0 +1,10 @@
+resource "google_pubsub_topic" "topic" {
+  name    = "${var.service_name}-${var.topic_name}"
+  project = var.project
+}
+
+resource "google_pubsub_subscription" "subscription" {
+  name    = "${var.service_name}-${var.subscription_name}"
+  topic   = google_pubsub_topic.topic.name
+  project = var.project
+}

--- a/tf/modules/pub-sub/outputs.tf
+++ b/tf/modules/pub-sub/outputs.tf
@@ -1,0 +1,7 @@
+output "topic" {
+  value = google_pubsub_topic.topic.name
+}
+
+output "subscription" {
+  value = google_pubsub_subscription.subscription.name
+}

--- a/tf/modules/pub-sub/variables.tf
+++ b/tf/modules/pub-sub/variables.tf
@@ -1,0 +1,19 @@
+variable "project" {
+  type = string
+  description = "The GCP project ID to deploy resources"
+}
+
+variable "service_name" {
+  type = string
+  description = "Deployed resources naming"
+}
+
+variable "topic_name" {
+  type        = string
+  description = "Name of the Pub/Sub topic to be created or used by the service"
+}
+
+variable "subscription_name" {
+  type        = string
+  description = "Name of the Pub/Sub subscription attached to the topic and used by the service"
+}


### PR DESCRIPTION
## Summary

Extends the Terraform template with several new optional infrastructure capabilities and hardens existing modules. All new modules are wired into `tf/dev` and exposed via root variables/`terraform.tfvars`.

## What's changed

### New modules
- **`monitoring/`** — Cloud Monitoring notification channels (email and/or Slack) and alert policies:
  - Cloud Run `5xx` errors (metric threshold, always on)
  - App `ERROR`-level logs (matches Cloud Logging `severity>=ERROR` or Pino `jsonPayload.level>=50`)
  - Cloud Build **deploy** and **migration** trigger failures
  - Each alert links straight to the relevant Logs Explorer query / failed build. Gated by `enable_deploy_alert` / `enable_migration_alert` / `enable_error_log_alert`.
- **`bucket/`** — reusable Cloud Storage bucket module (private/public, CORS for browser uploads, IAM for the Cloud Run SA). A `public_bucket` is provisioned in `tf/dev`.
- **`cloud-scheduler/`** — generic Cloud Scheduler cron-job module (HTTP target, configurable schedule/method/headers/body). Wired as commented-out examples in `tf/dev/main.tf`.
- **`pub-sub/`** — Pub/Sub topic + subscription module (commented-out example in `tf/dev/main.tf`).

### Module hardening
- **`cloud-sql/`** — automated **backups + point-in-time recovery** (7-day transaction-log retention), configurable `authorized_networks` via `allowed_ips` (replaces the open `0.0.0.0/0` default), and configurable `database_flags`.
- **`cloud-run/`** — adds `project_number` variable; fixes misspelled IAM resource names (`cloub_*` → `cloud_*`).
- **`project-api/`** — enables the `monitoring.googleapis.com` API.

### Config & misc
- `tf/dev` root: new variables and `terraform.tfvars` entries for alerting (`alert_emails`, `slack_channel_name`, `slack_auth_token_secret_id`), public bucket, SQL allowed IPs / flags, `project_number`, and API env vars / secret keys.
- `tfstate` bucket name now includes `service_name`.
- **Dockerfile**: base image `node:20` → `node:22`; `npm i` → `npm ci --omit=dev`.
- **README**: new “📊 Monitoring & Alerting” section with a Slack-alerts setup tutorial and updated component list.

## Notes for reviewers
- The README's component list mentions **Redis (Memorystore)**, but no Redis/Memorystore module is included in this diff — worth confirming whether that's intended for a follow-up or should be removed from the docs.
- The Cloud Scheduler and Pub/Sub modules are added but only referenced as commented-out examples in `tf/dev/main.tf`.
- `tf/prod` is referenced in the README but not updated here; the wiring lands only in `tf/dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)